### PR TITLE
bender: Add writeback cache configuration

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -43,6 +43,16 @@ sources:
           - core/mmu_sv39/ptw.sv
           - core/cva6_accel_first_pass_decoder_stub.sv
 
+      - target: cv64a6_imafdc_sv39_wb
+        files:
+          - core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+          - core/include/riscv_pkg.sv
+          - core/include/ariane_pkg.sv
+          - core/mmu_sv39/tlb.sv
+          - core/mmu_sv39/mmu.sv
+          - core/mmu_sv39/ptw.sv
+          - core/cva6_accel_first_pass_decoder_stub.sv
+
       - target: cv32a6_imac_sv0
         files:
           - core/include/cv32a6_imac_sv0_config_pkg.sv


### PR DESCRIPTION
For the `fesvr` to work, we need the write-back cache: There is no possibility to invalidate cache lines currently and the `fence` instructions in the `wt` cache does not invalidate (bug?).

I used this branch for the test shown here: https://github.com/axelera-ai/hw.riscv/pull/421 and tested it working.

If you agree with this change, how shall we do this merge? Create a new release branch?
